### PR TITLE
Revert "Add snapshot resolver repository for Apache Maven Repository"

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ This project exposes the following utility function which can be helpful in othe
 * `SonatypeApachePlugin.addFileToMetaInf`: This function is used internally (i.e. with keys such
   as `apacheSonatypeLicenseFile`) to mark files which will be added to the `META-INF` folder in created artifacts. You
   can manually call this function if you want to add other files to `META-INF` folder in generated artifacts.
-* `autoImport.SonatypeApacheSnapshotResolver`: Add this to your resolvers (
-  i.e. `resolvers += SonatypeApacheSnapshotResolver`) in order to resolve snapshot artifacts from Apache's Maven
-  repository.
 
 ## FAQ/Notes
 

--- a/src/main/scala/org/mdedetrich/apache/sonatype/SonatypeApachePlugin.scala
+++ b/src/main/scala/org/mdedetrich/apache/sonatype/SonatypeApachePlugin.scala
@@ -8,14 +8,7 @@ import xerial.sbt.Sonatype.SonatypeKeys._
 
 object SonatypeApachePlugin extends AutoPlugin {
 
-  object autoImport extends SonatypeApacheKeys {
-
-    /** Contains the Apache Maven Snapshot repository, add this to your project using `.settings` so you can resolve
-      * snapshot artifacts.
-      */
-    val SonatypeApacheSnapshotResolver: Resolver =
-      "Apache Nexus Snapshots".at(s"https://repository.apache.org/content/repositories/snapshots/")
-  }
+  object autoImport extends SonatypeApacheKeys
 
   import autoImport._
 

--- a/src/sbt-test/sbt-apache-sonatype/simple/build.sbt
+++ b/src/sbt-test/sbt-apache-sonatype/simple/build.sbt
@@ -1,8 +1,6 @@
 ThisBuild / scalaVersion                 := "2.13.10"
 ThisBuild / apacheSonatypeProjectProfile := "project"
 
-resolvers += SonatypeApacheSnapshotResolver
-
 TaskKey[Unit]("check-organization-name") := {
   val name = "Apache Software Foundation"
   if (organizationName.value != name && (ThisBuild / organizationName).value != name)


### PR DESCRIPTION
This reverts commit 51e57be6d0c6bb7f53c5d6e84592addb3666ccdd.

The feature did not end up being as useful as original thought. This is due to the fact we are currently resolving https://github.com/apache/incubator-pekko-sbt-paradox as a snapshot but because its an sbt plugin (and not a standard runtime library) we would need to add sbt-apache-sonatype as a library (not as an sbt plugin because you would need to define `apacheSonatypeProjectProfile` in `projects/plugins.sbt` which makes no sense) and this currently doesn't seem possible in sbt (https://github.com/sbt/librarymanagement/pull/409 appears to fix this).

Generally speaking this is not the best place to put the snapshot resolver anyways, the demographic for this plugin is Apache projects using sbt where as the snapshot resolver would be useful for anyone that wants to resolve snapshots in the Apache maven repo which is why https://github.com/sbt/librarymanagement/pull/411 was created, adding it into sbt into the standard `Resolver` object.