### PR TITLE
Set publishTo

### DIFF
--- a/src/main/scala/org/mdedetrich/apache/sonatype/SonatypeApachePlugin.scala
+++ b/src/main/scala/org/mdedetrich/apache/sonatype/SonatypeApachePlugin.scala
@@ -86,7 +86,8 @@ object SonatypeApachePlugin extends AutoPlugin {
     },
     apacheSonatypeLicenseFile    := baseDir.value / "LICENSE",
     apacheSonatypeNoticeFile     := baseDir.value / "NOTICE",
-    apacheSonatypeDisclaimerFile := None
+    apacheSonatypeDisclaimerFile := None,
+    publishTo                    := sonatypePublishToBundle.value
   ) ++ inConfig(Compile)(
     Seq(
       resourceGenerators += {

--- a/src/sbt-test/sbt-apache-sonatype/simple/build.sbt
+++ b/src/sbt-test/sbt-apache-sonatype/simple/build.sbt
@@ -37,3 +37,10 @@ TaskKey[Unit]("check-pom-license-field") := {
     sys.error("licenses not set")
   ()
 }
+
+TaskKey[Unit]("check-publish-to-field") := {
+  val apacheSnapshotRepo =
+    "https://repository.apache.org/content/repositories/snapshots"
+  if (!publishTo.value.exists { case resolver: MavenRepository => resolver.root == apacheSnapshotRepo })
+    ()
+}

--- a/src/sbt-test/sbt-apache-sonatype/simple/test
+++ b/src/sbt-test/sbt-apache-sonatype/simple/test
@@ -6,3 +6,4 @@ $ must-mirror target/scala-2.13/resource_managed/main/META-INF/NOTICE NOTICE
 > checkPublishMavenStyle
 > checkPomIncludeRepository
 > checkPomLicenseField
+> checkPublishToField


### PR DESCRIPTION
So it turned out that this sbt plugin wasn't doing the most critical thing, setting the `publishTo` field. In the context of pekko projects this field was being set by another plugin (sbt-ci-release) which meant for the projects that didn't have `sbt-ci-release` then `publishTo` wasn't even being set.

Note that the value is exactly the same from sbt-ci-release (see https://github.com/sbt/sbt-ci-release/blob/0dad9ee3ab99c6f78493e2de3bc1364ecf3b9c00/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L179)