### PR TITLE
Update to sbt 1.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ set.
 Once this is done you can then publish your projects Maven artifacts into Apache's Nexus by using
 `publish`/`publishSigned` as is idiomatically done in sbt projects.
 
+This plugin requires at least sbt version 1.10.2.
+
 ## Usage
 
 Since this plugin is an [auto plugin](https://www.scala-sbt.org/1.x/api/sbt/AutoPlugin.html) that immediately triggers

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.2

--- a/src/main/scala/org/mdedetrich/apache/sonatype/ApacheSonatypePlugin.scala
+++ b/src/main/scala/org/mdedetrich/apache/sonatype/ApacheSonatypePlugin.scala
@@ -134,13 +134,6 @@ object ApacheSonatypePlugin extends AutoPlugin {
             .toList
         }
       },
-      // See https://issues.apache.org/jira/browse/LEGAL-28
-      packageSrc / mappings ++= {
-        Seq(
-          apacheSonatypeLicenseFile.value -> "META-INF/LICENSE",
-          apacheSonatypeNoticeFile.value  -> "META-INF/NOTICE"
-        ) ++ apacheSonatypeDisclaimerFile.value.map(path => path -> "META-INF/DISCLAIMER").toSeq
-      },
       packageDoc / mappings ++= {
         Seq(
           apacheSonatypeLicenseFile.value -> "META-INF/LICENSE",

--- a/src/sbt-test/sbt-apache-sonatype/simple/test
+++ b/src/sbt-test/sbt-apache-sonatype/simple/test
@@ -2,6 +2,7 @@
 $ must-mirror target/scala-2.13/resource_managed/main/META-INF/LICENSE LICENSE
 $ must-mirror target/scala-2.13/resource_managed/main/META-INF/NOTICE NOTICE
 > packageSrc
+# See https://issues.apache.org/jira/browse/LEGAL-28
 > extractPackageSrcContents
 $ must-mirror target/scala-2.13/packageSrc/META-INF/LICENSE LICENSE
 $ must-mirror target/scala-2.13/packageSrc/META-INF/NOTICE NOTICE


### PR DESCRIPTION
Fixes #39

In sbt 1.10.2 the managed resources are automatically included in the packageSrc (https://github.com/sbt/sbt/pull/7630), and doing it again explicitly causes errors.