### PR TITLE
Support packageSrc in all versions of sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ set.
 Once this is done you can then publish your projects Maven artifacts into Apache's Nexus by using
 `publish`/`publishSigned` as is idiomatically done in sbt projects.
 
-This plugin requires at least sbt version 1.10.2.
-
 ## Usage
 
 Since this plugin is an [auto plugin](https://www.scala-sbt.org/1.x/api/sbt/AutoPlugin.html) that immediately triggers

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/LICENSE
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/LICENSE
@@ -1,0 +1,1 @@
+License file

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/NOTICE
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/NOTICE
@@ -1,0 +1,1 @@
+Notice file

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/build.sbt
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/build.sbt
@@ -1,0 +1,71 @@
+ThisBuild / scalaVersion                 := "2.13.10"
+ThisBuild / apacheSonatypeProjectProfile := "project"
+name                                     := "some-name"
+
+TaskKey[Unit]("check-organization") := {
+  val org = "org.apache.project"
+  if (
+    organization.value != org || (ThisBuild / organization).value != org || (sonatypeProfileName.value != org) || (ThisBuild / sonatypeProfileName).value != org
+  )
+    sys.error("apacheSonatypeProjectProfile not set")
+  ()
+}
+
+TaskKey[Unit]("check-organization-name") := {
+  val name = "Apache Software Foundation"
+  if (organizationName.value != name || (ThisBuild / organizationName).value != name)
+    sys.error("apacheSonatypeOrganizationName not set")
+  ()
+}
+
+TaskKey[Unit]("check-publish-maven-style") := {
+  val name = "Apache Software Foundation"
+  if (!publishMavenStyle.value && !(ThisBuild / publishMavenStyle).value)
+    sys.error("publishMavenStyle not set")
+  ()
+}
+
+TaskKey[Unit]("check-pom-include-repository") := {
+  val name = "Apache Software Foundation"
+  if (pomIncludeRepository.value.apply(null) && (ThisBuild / pomIncludeRepository).value.apply(null))
+    sys.error("pomIncludeRepository not set")
+  ()
+}
+
+TaskKey[Unit]("check-pom-license-field") := {
+  val apacheField = "Apache-2.0"
+  if (!licenses.value.exists { case (field, _) => field == apacheField })
+    sys.error("licenses not set")
+  ()
+}
+
+TaskKey[Unit]("check-publish-to-field") := {
+  val apacheSnapshotRepo =
+    "https://repository.apache.org/content/repositories/snapshots"
+  if (!publishTo.value.exists { case resolver: MavenRepository => resolver.root == apacheSnapshotRepo })
+    sys.error("publishTo not set")
+}
+
+TaskKey[Unit]("extract-packageSrc-contents") := {
+  val sourcesJar =
+    target.value / s"scala-${scalaBinaryVersion.value}" / s"${name.value}_${scalaBinaryVersion.value}-${version.value}-sources.jar"
+  val targetDir = target.value / s"scala-${scalaBinaryVersion.value}" / "packageSrc"
+
+  IO.unzip(sourcesJar, targetDir)
+}
+
+TaskKey[Unit]("extract-packageDoc-contents") := {
+  val sourcesJar =
+    target.value / s"scala-${scalaBinaryVersion.value}" / s"${name.value}_${scalaBinaryVersion.value}-${version.value}-javadoc.jar"
+  val targetDir = target.value / s"scala-${scalaBinaryVersion.value}" / "packageDoc"
+
+  IO.unzip(sourcesJar, targetDir)
+}
+
+TaskKey[Unit]("check-artifact-name") := {
+  val file     = makePom.value
+  val xml      = scala.xml.XML.loadFile(file)
+  val nameNode = (xml \ "name").text
+  if (nameNode != "Apache Some Name")
+    sys.error(s"expected artifact name to be Apache Some Name, instead got ${nameNode}")
+}

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/project/build.properties
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.1

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/project/plugins.sbt
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/test
+++ b/src/sbt-test/sbt-apache-sonatype/simple-pre-1.10.2/test
@@ -1,0 +1,20 @@
+> package
+$ must-mirror target/scala-2.13/resource_managed/main/META-INF/LICENSE LICENSE
+$ must-mirror target/scala-2.13/resource_managed/main/META-INF/NOTICE NOTICE
+> packageSrc
+# See https://issues.apache.org/jira/browse/LEGAL-28
+> extractPackageSrcContents
+$ must-mirror target/scala-2.13/packageSrc/META-INF/LICENSE LICENSE
+$ must-mirror target/scala-2.13/packageSrc/META-INF/NOTICE NOTICE
+> packageDoc
+> extractPackageDocContents
+$ must-mirror target/scala-2.13/packageDoc/META-INF/LICENSE LICENSE
+$ must-mirror target/scala-2.13/packageDoc/META-INF/NOTICE NOTICE
+> checkOrganization
+> checkOrganizationName
+> checkPublishMavenStyle
+> checkPomIncludeRepository
+> checkPomLicenseField
+> checkPublishToField
+> checkArtifactName
+


### PR DESCRIPTION
I know that @raboof had reservations about doing such a change, but I wanted to see whether the deterministic issues carried over to `sbtVersion` (which I highly doubt).

@raboof Let me know if you still have reservations with this change, the idea is to merge this into main and manually test this against various pekko projects against a snapshot of sbt-apache-sonatype and if there is an issue then revert this commit.