### PR TITLE
update sbt-sonatype and sbt-pgp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ lazy val scala212 = "2.12.20"
 ThisBuild / crossScalaVersions := Seq(scala212)
 ThisBuild / scalaVersion       := scala212
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
-addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.2.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
 enablePlugins(SbtPlugin)
 
 ThisBuild / versionScheme          := Some("early-semver")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
-addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.2.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.2")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.24.0")
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.12.1")


### PR DESCRIPTION
We probably still need sbt-sonatype to work with Apache's Nexus instance (repository.apache.org).
Sonatype Central is a different issue and one that does currently affect ASF projects.